### PR TITLE
Add publisher for image with circle

### DIFF
--- a/launch/visual_servoing.launch
+++ b/launch/visual_servoing.launch
@@ -16,11 +16,15 @@
         <param name="~padding_vertical" type="int" value="$(arg padding_vertical)"/>
         
     </node>
-<!-- 
-    <node name="image_view" pkg="image_view" type="image_view" respawn="false" output="screen">
+
+    <node name="image_view_vspub" pkg="image_view" type="image_view" respawn="false" output="screen">
+        <remap from="image" to="/vs/robot_0/image_pub"/>
+    </node>
+    <!-- 
+    <node name="image_view_feed" pkg="image_view" type="image_view" respawn="false" output="screen">
         <remap from="image" to="$(arg camera_feed_topic)"/>
     </node>
- -->
+     -->
     <!--
     <group ns="/vs">
     


### PR DESCRIPTION
This commit closes issue #19.

In order to replace imshow, which stop the process, the image is publish to a topic after being converted from ROS to OpenCV image thanks to the rosbridge function.